### PR TITLE
IntentIQ S2S bid enhancement (work in progress)

### DIFF
--- a/core/BidContext.js
+++ b/core/BidContext.js
@@ -52,10 +52,13 @@ function withNativeRequest(imp) {
 }
 
 export class BidContext {
-  constructor({ ssp, dsp, destination, impressions, device, user, publisher, privacy, content, signals, tmax, raw }) {
+  constructor({ ssp, dsp, destination, inventory, impressions, device, user, publisher, privacy, content, signals, tmax, raw }) {
     this.ssp = ssp;
     this.dsp = dsp;
     this.destination = destination;
+
+    // 'app' | 'site' | 'dooh' | null — which inventory object the request carried
+    this.inventory = inventory ?? null;
 
     // Array of impressions — pipeline works with [0], but patches broadcast to all
     this.impressions = (impressions ?? []).map(imp => withNativeRequest({

--- a/core/protocol/openrtb25/parser.js
+++ b/core/protocol/openrtb25/parser.js
@@ -20,6 +20,11 @@ export function parse(body, signal) {
     tmax: body.tmax ?? 0,
     raw: body,
 
+    // Which of the mutually exclusive inventory objects the request carries.
+    // Derived facts like publisher.bundle and content.page are optional, so
+    // they cannot stand in for this.
+    inventory: body.app ? 'app' : body.site ? 'site' : body.dooh ? 'dooh' : null,
+
     impressions: parseImpressions(body.imp ?? []),
 
     device: {

--- a/features/intent-iq/README.md
+++ b/features/intent-iq/README.md
@@ -1,0 +1,22 @@
+# intent-iq
+
+IntentIQ S2S Bid Enhancement: resolves external ids for the user, merges them
+into `user.ext.eids` before the DSP call, and reports the rendered impression
+back so IntentIQ can measure lift.
+
+- Stage: `prebid-dsp`, plus a tracking consumer for the impression report
+- Namespace: `intentIq`
+- Ships `enabled: false`
+
+A region is a `(host, dpi)` pair, not just a host: the GDPR endpoint is a
+separate IntentIQ account. Only the countries IntentIQ documents are served.
+
+The cache key carries no `dpi` on purpose, so a deployment without an account
+still reads the cache that deployments with one populate. Without a `dpi` we
+never call out and never report impressions.
+
+Rate is discovered rather than configured: a local bucket admits requests, and
+workers agree on a fleet-wide limit per `dpi` through Redis at most once a
+second, sharing it in proportion to demand.
+
+Fail-open on every branch — no eids simply means the request passes through.

--- a/features/intent-iq/cache.js
+++ b/features/intent-iq/cache.js
@@ -1,0 +1,35 @@
+// Entries hold the dpi that fetched them. eids are a property of the user and
+// travel between accounts, but abTestUuid identifies one account's response —
+// reporting someone else's would corrupt their measurement, so the reader only
+// uses it when the dpi matches. Omitting it is allowed by the reporting spec.
+export function entryFor(eids, abTestUuid, dpi) {
+  return { eids: eids ?? [], abTestUuid: abTestUuid ?? null, dpi: dpi ?? null };
+}
+
+export function abTestUuidFor(entry, dpi) {
+  return entry?.dpi && entry.dpi === dpi ? entry.abTestUuid : null;
+}
+
+// cttl is theirs to set; cap it so one bad value cannot pin stale eids for
+// days. The cohort tier is a bucket of devices behind one IP, not a device, so
+// it never outlives coarseTtlMs.
+export function ttlFor(cttl, tier, cfg) {
+  const n = Number(cttl);
+  const base = Number.isFinite(n) && n > 0 ? n : cfg.ttlMs;
+  const capped = Math.min(base, cfg.maxTtlMs);
+  return tier === 'cohort' ? Math.min(capped, cfg.coarseTtlMs) : capped;
+}
+
+export async function read(redis, key) {
+  const raw = await redis.get(key);
+  if (raw == null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function write(redis, key, entry, ttlMs) {
+  await redis.set(key, JSON.stringify(entry), { PX: Math.max(1, Math.round(ttlMs)) });
+}

--- a/features/intent-iq/client.js
+++ b/features/intent-iq/client.js
@@ -1,0 +1,96 @@
+import http2 from 'node:http2';
+
+const PATH = '/profiles_engine/ProfilesEngineServlet';
+const S2S_STATIC = [['at', 39], ['mi', 10], ['pt', 17], ['dpn', 1], ['srvrReq', 'true']];
+const REPORT_STATIC = [['at', 45], ['rtype', 1]];
+const QPS_MARKER = 'QPS_LIMIT_REACHED';
+
+const enc = v => encodeURIComponent(String(v));
+const query = pairs => pairs.map(([k, v]) => `${enc(k)}=${enc(v)}`).join('&');
+
+const sessions = new Map();
+
+function session(host) {
+  const live = sessions.get(host);
+  if (live && !live.destroyed && !live.closed) return live;
+
+  const s = http2.connect(`https://${host}`);
+  const drop = () => { if (sessions.get(host) === s) sessions.delete(host); };
+  s.on('error', drop);
+  s.once('close', drop);
+  s.once('goaway', drop);
+  sessions.set(host, s);
+  return s;
+}
+
+export function closeAll() {
+  for (const s of sessions.values()) s.close();
+  sessions.clear();
+}
+
+function get(host, path, headers, timeoutMs) {
+  return new Promise(resolve => {
+    let done = false;
+    const finish = out => { if (!done) { done = true; resolve(out); } };
+
+    let req;
+    try {
+      req = session(host).request({ ...headers, ':method': 'GET', ':path': path });
+    } catch (e) {
+      return finish({ status: 'error', message: e.message });
+    }
+
+    const chunks = [];
+    let code = 0;
+    req.on('response', h => { code = h[':status']; });
+    req.on('data', c => chunks.push(c));
+    req.on('end', () => finish({ status: 'ok', code, body: Buffer.concat(chunks).toString() }));
+    req.once('error', e => { req.destroy(); finish({ status: 'error', message: e.message }); });
+    req.setTimeout(timeoutMs, () => { req.destroy(); finish({ status: 'timeout' }); });
+    req.end();
+  });
+}
+
+export function s2sPath(dpi, identity) {
+  const parts = [...S2S_STATIC, ['dpi', dpi]];
+  for (const [k, v] of Object.entries(identity)) parts.push([k, v]);
+  if (identity.iiquid) parts.push(['iiqidtype', 2]);
+  return `${PATH}?${query(parts)}`;
+}
+
+export function reportPath(dpi, rdata) {
+  return `${PATH}?${query([...REPORT_STATIC, ['dpi', dpi], ['rdata', JSON.stringify(rdata)]])}`;
+}
+
+// Their non-200 signals overlap: 302 means no data rather than a redirect, and
+// the QPS refusal arrives in the body of an otherwise fine response.
+export function interpretEids(res) {
+  if (res.status !== 'ok') return { outcome: res.status === 'timeout' ? 'timeout' : 'error' };
+  if (res.code === 302) return { outcome: 'nodata' };
+  if (res.body?.includes(QPS_MARKER)) return { outcome: 'qps' };
+  if (res.code >= 400) return { outcome: 'error' };
+
+  let body;
+  try {
+    body = JSON.parse(res.body);
+  } catch {
+    return { outcome: 'badjson' };
+  }
+
+  return {
+    outcome: 'ok',
+    eids: body.isOptedOut ? [] : (body.data?.eids ?? []),
+    abTestUuid: body.abTestUuid ?? null,
+    cttl: body.cttl,
+  };
+}
+
+export async function fetchEids({ host, dpi, identity, gdpr, consent, timeoutMs }) {
+  const headers = gdpr === 1 && consent ? { 'gdpr-consent': consent } : {};
+  return interpretEids(await get(host, s2sPath(dpi, identity), headers, timeoutMs));
+}
+
+export async function reportImpression({ host, dpi, rdata, timeoutMs }) {
+  const res = await get(host, reportPath(dpi, rdata), {}, timeoutMs);
+  return { ok: res.status === 'ok' && res.code < 400, code: res.code };
+}

--- a/features/intent-iq/client.js
+++ b/features/intent-iq/client.js
@@ -54,7 +54,6 @@ function get(host, path, headers, timeoutMs) {
 export function s2sPath(dpi, identity) {
   const parts = [...S2S_STATIC, ['dpi', dpi]];
   for (const [k, v] of Object.entries(identity)) parts.push([k, v]);
-  if (identity.iiquid) parts.push(['iiqidtype', 2]);
   return `${PATH}?${query(parts)}`;
 }
 

--- a/features/intent-iq/config.json
+++ b/features/intent-iq/config.json
@@ -1,0 +1,30 @@
+{
+  "enabled": false,
+  "redisUrl": "",
+  "regions": {
+    "us": {
+      "host": "",
+      "dpi": ""
+    },
+    "apac": {
+      "host": "",
+      "dpi": ""
+    },
+    "eu": {
+      "host": "",
+      "dpi": ""
+    }
+  },
+  "awaitFetch": true,
+  "timeoutMs": 30,
+  "ttlMs": 43200000,
+  "coarseTtlMs": 3600000,
+  "maxTtlMs": 86400000,
+  "reporting": {
+    "enabled": true,
+    "host": "reports-s2s.intentiq.com"
+  },
+  "targets": [
+    {}
+  ]
+}

--- a/features/intent-iq/identity.js
+++ b/features/intent-iq/identity.js
@@ -110,9 +110,13 @@ export function identityFor(ctx) {
   const ref = ctx.publisher?.bundle ?? ctx.publisher?.domain ?? ctx.publisher?.name;
   if (ref) identity.ref = ref;
 
+  // Sent as received. Their footnote puts the uppercase rule on IDFV only, and
+  // an AAID is conventionally lower case — normalising it would send an id no
+  // other integration sends. The cache key uppercases separately, to collapse
+  // case variants of one device into one entry.
   if (hasRealIfa(d.ifa)) {
     identity.idtype = CTV_TYPES.has(d.type) ? IDTYPE.CTV : IDTYPE.IFA;
-    identity.pcid = d.ifa.toUpperCase();
+    identity.pcid = d.ifa;
   } else if (ctx.user?.id) {
     identity.idtype = IDTYPE.COOKIE;
     identity.pcid = ctx.user.id;

--- a/features/intent-iq/identity.js
+++ b/features/intent-iq/identity.js
@@ -1,0 +1,132 @@
+const IIQ_SOURCE = 'intentiq.com';
+
+// AdCOM 1.0 Device Types.
+const FORM = { 1: 'mobile', 2: 'desktop', 3: 'ctv', 4: 'mobile', 5: 'tablet', 6: 'device', 7: 'ctv', 8: 'ooh' };
+const CTV_TYPES = new Set([3, 7]);
+
+export const IDTYPE = { COOKIE: 0, IDFV: 1, IFA: 4, CTV: 8 };
+
+// All-zero IFA means opted out — every such device would share one key.
+export function hasRealIfa(ifa) {
+  if (!ifa) return false;
+  for (let i = 0; i < ifa.length; i++) {
+    if (ifa[i] !== '0' && ifa[i] !== '-') return true;
+  }
+  return false;
+}
+
+const slug = s => String(s).toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+const UA_OS = [
+  [/(?:iPhone OS|CPU OS) (\d+)[._](\d+)/i, 'ios'],
+  [/Android (\d+)(?:\.(\d+))?/i, 'android'],
+  [/Mac OS X (\d+)[._](\d+)/i, 'macos'],
+  [/Windows NT (\d+)(?:\.(\d+))?/i, 'windows'],
+  [/CrOS \S+ (\d+)\.(\d+)/i, 'chromeos'],
+];
+
+function uaOs(ua) {
+  for (const [re, name] of UA_OS) {
+    const m = ua ? re.exec(ua) : null;
+    if (m) return { name, version: m[2] ? `${m[1]}.${m[2]}` : m[1] };
+  }
+  return null;
+}
+
+// Order matters, and gecko must not match bare "Gecko": every WebKit and Blink
+// UA carries the literal "like Gecko".
+const ENGINES = [
+  [/edg|chrom|crios|opr|opera|brave|samsungbrowser/i, 'blink'],
+  [/firefox|gecko\/\d/i, 'gecko'],
+  [/safari|webkit/i, 'webkit'],
+];
+
+function matchEngine(s) {
+  for (const [re, engine] of ENGINES) if (re.test(s)) return engine;
+  return null;
+}
+
+function engineOf(device) {
+  for (const brand of device.browsers ?? []) {
+    const engine = matchEngine(brand);
+    if (engine) return engine;
+  }
+  return (device.ua ? matchEngine(device.ua) : null) ?? 'engine?';
+}
+
+function formOf(device) {
+  if (FORM[device.type]) return FORM[device.type];
+  const ua = device.ua;
+  if (!ua) return 'form?';
+  if (/iPad|Tablet/i.test(ua)) return 'tablet';
+  if (/Mobile|iPhone|iPod|Android/i.test(ua)) return 'mobile';
+  return 'desktop';
+}
+
+// From the protocol: bundle is app-only, page is site-only.
+export function surfaceOf(ctx) {
+  if (ctx.publisher?.bundle) return 'app';
+  if (ctx.content?.page) return 'site';
+  return 'surface?';
+}
+
+// Coarse components instead of the raw UA, so a patch-version bump does not
+// mint a new cache entry. UA only fills what the protocol left empty.
+export function cohortOf(ctx) {
+  const d = ctx.device ?? {};
+  if (!d.ip) return null;
+
+  const ua = (d.os && d.osv) ? null : uaOs(d.ua);
+  const os = d.os ? slug(d.os) : ua?.name ?? 'os?';
+  const osv = d.osv ? d.osv.split('.').slice(0, 2).join('.') : ua?.version ?? '?';
+
+  return `${os}_${osv}_${formOf(d)}_${engineOf(d)}_${surfaceOf(ctx)}_${d.ip}`;
+}
+
+function eidValue(eids, source) {
+  return eids?.find(e => e.source === source)?.uids?.[0]?.id ?? null;
+}
+
+// Priority per the caching guide. Their "first-party ID" tier is absent: its
+// input (SharedID / IIQ 1P ID) only exists via the browser integration.
+export const KEY_TIERS = ['ifa', 'cohort', 'iiquid'];
+
+// dpi-free on purpose: deployments without an account read the cache that
+// deployments with one populate.
+export function cacheKeyFor(ctx) {
+  const ifa = ctx.device?.ifa;
+  if (hasRealIfa(ifa)) return { tier: 'ifa', key: `iiq:ifa:${ifa.toUpperCase()}` };
+
+  const cohort = cohortOf(ctx);
+  if (cohort) return { tier: 'cohort', key: `iiq:ua:${cohort}` };
+
+  const iiquid = eidValue(ctx.user?.eids, IIQ_SOURCE);
+  if (iiquid) return { tier: 'iiquid', key: `iiq:uid:${iiquid}` };
+
+  return null;
+}
+
+export function identityFor(ctx) {
+  const d = ctx.device ?? {};
+  const identity = {};
+
+  if (d.ip) identity.ip = d.ip;
+  if (d.ipv6) identity.ipv6 = d.ipv6;
+  if (d.ua) identity.uas = d.ua;
+
+  const ref = ctx.publisher?.bundle ?? ctx.publisher?.domain ?? ctx.publisher?.name;
+  if (ref) identity.ref = ref;
+
+  if (hasRealIfa(d.ifa)) {
+    identity.idtype = CTV_TYPES.has(d.type) ? IDTYPE.CTV : IDTYPE.IFA;
+    identity.pcid = d.ifa.toUpperCase();
+  } else if (ctx.user?.id) {
+    identity.idtype = IDTYPE.COOKIE;
+    identity.pcid = ctx.user.id;
+  }
+
+  const iiquid = eidValue(ctx.user?.eids, IIQ_SOURCE);
+  if (iiquid) identity.iiquid = iiquid;
+
+  return identity;
+}

--- a/features/intent-iq/identity.js
+++ b/features/intent-iq/identity.js
@@ -63,13 +63,6 @@ function formOf(device) {
   return 'desktop';
 }
 
-// From the protocol: bundle is app-only, page is site-only.
-export function surfaceOf(ctx) {
-  if (ctx.publisher?.bundle) return 'app';
-  if (ctx.content?.page) return 'site';
-  return 'surface?';
-}
-
 // Coarse components instead of the raw UA, so a patch-version bump does not
 // mint a new cache entry. UA only fills what the protocol left empty.
 export function cohortOf(ctx) {
@@ -80,7 +73,7 @@ export function cohortOf(ctx) {
   const os = d.os ? slug(d.os) : ua?.name ?? 'os?';
   const osv = d.osv ? d.osv.split('.').slice(0, 2).join('.') : ua?.version ?? '?';
 
-  return `${os}_${osv}_${formOf(d)}_${engineOf(d)}_${surfaceOf(ctx)}_${d.ip}`;
+  return `${os}_${osv}_${formOf(d)}_${engineOf(d)}_${ctx.inventory ?? 'inv?'}_${d.ip}`;
 }
 
 function eidValue(eids, source) {

--- a/features/intent-iq/index.js
+++ b/features/intent-iq/index.js
@@ -1,0 +1,24 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadConfig } from '../../core/config.js';
+import hook from './prebid-dsp.js';
+import { createConsumer } from './reporting.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dir, '../..');
+
+const LABEL = 'intent-iq/prebid-dsp';
+
+export function register(registry, services) {
+  const cfg = loadConfig(resolve(__dir, 'config.json'), resolve(ROOT, 'config.json'), 'intentIq');
+
+  if (cfg.enabled) {
+    registry.register('prebid-dsp', null, hook, LABEL);
+
+    if (cfg.reporting?.enabled) {
+      services?.get?.('tracking')?.addConsumer(createConsumer(cfg));
+    }
+  }
+
+  return { side: 'feature', bidder: 'intent-iq', stage: 'prebid-dsp', label: LABEL };
+}

--- a/features/intent-iq/prebid-dsp.js
+++ b/features/intent-iq/prebid-dsp.js
@@ -1,0 +1,159 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadConfig, resolveConfig, variantFor } from '../../core/config.js';
+import { mergeConfig } from '../../core/utils.js';
+import { matchesTarget } from '../../core/registry.js';
+import { defineCounter, defineHistogram } from '../../core/metrics.js';
+import { getRedis } from './redis.js';
+import { resolveRegion } from './regions.js';
+import { cacheKeyFor, identityFor } from './identity.js';
+import { entryFor, abTestUuidFor, ttlFor, read, write } from './cache.js';
+import { fetchEids } from './client.js';
+import { createThrottle } from './throttle.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dir, '../..');
+
+const _cfg = loadConfig(resolve(__dir, 'config.json'), resolve(ROOT, 'config.json'), 'intentIq');
+
+const total = defineCounter(
+  'smash_intent_iq_total',
+  'IntentIQ decisions by result',
+  ['endpoint_id', 'ssp_id', 'result', 'tier', 'variant'],
+);
+
+const eidsPerBid = defineHistogram(
+  'smash_intent_iq_eids',
+  'eids attached per enriched request',
+  ['tier'],
+  [1, 2, 3, 5, 8, 13, 21],
+);
+
+const fetchMs = defineHistogram(
+  'smash_intent_iq_fetch_milliseconds',
+  'IntentIQ S2S call duration by outcome',
+  ['outcome'],
+  [5, 10, 25, 50, 100, 250, 500, 1000],
+);
+
+export const throttle = createThrottle({ redis: () => getRedis(_cfg.redisUrl) });
+
+function record(ctx, result, tier = 'none') {
+  total.inc({
+    endpoint_id: ctx.dsp?.endpointId ?? ctx.dsp?.id ?? 'unknown',
+    ssp_id: ctx.ssp?.endpointId ?? ctx.ssp?.id ?? 'unknown',
+    result,
+    tier,
+    variant: variantFor(ctx, 'intentIq'),
+  });
+}
+
+// Never replace what the SSP sent: their eids are the input we read iiquid from,
+// and dropping them would lose data we do not own.
+function mergeEids(incoming, fresh) {
+  const seen = new Set((incoming ?? []).map(e => e.source));
+  const merged = [...(incoming ?? [])];
+  for (const eid of fresh) if (!seen.has(eid.source)) merged.push(eid);
+  return merged;
+}
+
+function apply(ctx, eids, tier) {
+  if (!eids?.length) return false;
+  const merged = mergeEids(ctx.user?.eids, eids);
+  ctx.set('user.eids', merged);
+  ctx.set('user.ext.eids', merged);
+  eidsPerBid.observe({ tier }, eids.length);
+  return true;
+}
+
+function trackForReporting(ctx, dpi, abTestUuid) {
+  ctx.track('iiq', {
+    dpi,
+    abTestUuid,
+    bidder: ctx.dsp?.knownBidder ?? null,
+    placementId: ctx.impression?.inventoryCode ?? '',
+    vrref: ctx.publisher?.bundle ?? ctx.publisher?.domain ?? '',
+    ip: ctx.device?.ip ?? null,
+    ua: ctx.device?.ua ?? null,
+  });
+}
+
+async function fetchAndStore(ctx, cfg, redis, region, keyed, deps) {
+  const started = Date.now();
+  const res = await deps.fetch({
+    host: region.host,
+    dpi: region.dpi,
+    identity: identityFor(ctx),
+    gdpr: ctx.privacy?.gdpr,
+    consent: ctx.privacy?.consent,
+    timeoutMs: cfg.timeoutMs,
+  });
+  fetchMs.observe({ outcome: res.outcome }, Date.now() - started);
+
+  deps.gate.record(region.dpi, res.outcome === 'ok' ? 'ok' : res.outcome === 'qps' ? 'qps' : 'error');
+  if (res.outcome !== 'ok') return res;
+
+  try {
+    const entry = entryFor(res.eids, res.abTestUuid, region.dpi);
+    await write(redis, keyed.key, entry, ttlFor(res.cttl, keyed.tier, cfg));
+  } catch { /* the eids are still usable */ }
+
+  return res;
+}
+
+export async function _run(ctx, cfg, redis, deps = {}) {
+  const d = { fetch: fetchEids, gate: throttle, ...deps };
+
+  if (!(cfg.targets ?? [{}]).some(t => matchesTarget(t, ctx))) {
+    record(ctx, 'skip_no_target');
+    return ctx;
+  }
+
+  const keyed = cacheKeyFor(ctx);
+  if (!keyed) { record(ctx, 'skip_no_key'); return ctx; }
+
+  // Without a cache every request becomes a fetch, which burns the account
+  // instead of degrading.
+  if (!redis) { record(ctx, 'skip_redis', keyed.tier); return ctx; }
+
+  const region = resolveRegion(ctx.device?.country, cfg.regions);
+
+  try {
+    const hit = await read(redis, keyed.key);
+    if (hit) {
+      if (region.dpi) trackForReporting(ctx, region.dpi, abTestUuidFor(hit, region.dpi));
+      record(ctx, apply(ctx, hit.eids, keyed.tier) ? 'cache_hit' : 'cache_hit_empty', keyed.tier);
+      return ctx;
+    }
+  } catch {
+    record(ctx, 'redis_error', keyed.tier);
+    return ctx;
+  }
+
+  if (region.reason) { record(ctx, region.reason, keyed.tier); return ctx; }
+  if (!d.gate.admit(region.dpi)) { record(ctx, 'throttled', keyed.tier); return ctx; }
+
+  if (!cfg.awaitFetch) {
+    void fetchAndStore(ctx, cfg, redis, region, keyed, d).catch(() => {});
+    record(ctx, 'deferred', keyed.tier);
+    return ctx;
+  }
+
+  const res = await fetchAndStore(ctx, cfg, redis, region, keyed, d);
+  if (res.outcome !== 'ok') {
+    record(ctx, res.outcome === 'timeout' ? 'fetch_timeout' : 'fetch_error', keyed.tier);
+    return ctx;
+  }
+
+  trackForReporting(ctx, region.dpi, res.abTestUuid);
+  record(ctx, apply(ctx, res.eids, keyed.tier) ? 'enriched' : 'fetched_empty', keyed.tier);
+  return ctx;
+}
+
+export default async function intentIqHook(ctx) {
+  const cfg = mergeConfig(resolveConfig(ctx, _cfg, 'intentIq'), ctx.dsp?.params?.intentIq);
+  if (!cfg.enabled) return ctx;
+
+  const redis = cfg.redisUrl ? await getRedis(cfg.redisUrl) : null;
+  return _run(ctx, cfg, redis);
+}

--- a/features/intent-iq/redis.js
+++ b/features/intent-iq/redis.js
@@ -1,0 +1,34 @@
+import { createClient } from 'redis';
+
+let _conn = null;
+
+async function connect(url) {
+  // reconnectStrategy: false — otherwise node-redis retries forever and
+  // connect() never rejects, so a dead Redis hangs inside tmax instead of
+  // failing open. createClient is inside the try: it throws synchronously on a
+  // malformed url.
+  const client = createClient({ url, socket: { reconnectStrategy: false, connectTimeout: 300 } });
+  client.on('error', () => {});
+  await client.connect();
+  return client;
+}
+
+// Memoises the promise, not the client. Awaiting the client instead lets every
+// concurrent caller past the null check, each opening a connection that is then
+// orphaned — still connected, never used, never closed.
+export function getRedis(url) {
+  if (!url) return null;
+  if (_conn) return _conn;
+
+  try {
+    _conn = connect(url).catch(() => { _conn = null; return null; });
+  } catch {
+    _conn = null;
+    return null;
+  }
+  return _conn;
+}
+
+export function _reset() {
+  _conn = null;
+}

--- a/features/intent-iq/redis.js
+++ b/features/intent-iq/redis.js
@@ -1,12 +1,12 @@
 import { createClient } from 'redis';
 
-let _conn = null;
+const _conns = new Map();
 
 async function connect(url) {
   // reconnectStrategy: false — otherwise node-redis retries forever and
   // connect() never rejects, so a dead Redis hangs inside tmax instead of
-  // failing open. createClient is inside the try: it throws synchronously on a
-  // malformed url.
+  // failing open. createClient throws synchronously on a malformed url, but
+  // this function is async, so that surfaces as a rejection like any other.
   const client = createClient({ url, socket: { reconnectStrategy: false, connectTimeout: 300 } });
   client.on('error', () => {});
   await client.connect();
@@ -16,19 +16,34 @@ async function connect(url) {
 // Memoises the promise, not the client. Awaiting the client instead lets every
 // concurrent caller past the null check, each opening a connection that is then
 // orphaned — still connected, never used, never closed.
-export function getRedis(url) {
+//
+// Keyed by url: the throttle reads the static module config and the hook reads
+// the per-request one, so the two can ask for different servers.
+export function getRedis(url, connectFn = connect) {
   if (!url) return null;
-  if (_conn) return _conn;
+
+  const hit = _conns.get(url);
+  if (hit) return hit;
+
+  let pending;
+  const forget = () => { if (_conns.get(url) === pending) _conns.delete(url); };
 
   try {
-    _conn = connect(url).catch(() => { _conn = null; return null; });
+    pending = connectFn(url).then(client => {
+      // reconnectStrategy is false, so a connection that drops never comes
+      // back. Without this the dead client is memoised for the life of the
+      // process and every later request fails against it.
+      client.on('end', forget);
+      return client;
+    }).catch(() => { forget(); return null; });
   } catch {
-    _conn = null;
     return null;
   }
-  return _conn;
+
+  _conns.set(url, pending);
+  return pending;
 }
 
 export function _reset() {
-  _conn = null;
+  _conns.clear();
 }

--- a/features/intent-iq/regions.js
+++ b/features/intent-iq/regions.js
@@ -1,0 +1,36 @@
+// A region is a (host, dpi) pair — the GDPR one is a separate IIQ account, not
+// just another host. Countries are ISO-3166-1 alpha-3 (device.geo.country).
+// `eu` is the seven countries IntentIQ covers, NOT the EU and NOT GDPR
+// jurisdictions — extend only from their docs.
+export const COUNTRY_REGION = {
+  USA: 'us', CAN: 'us', MEX: 'us', BRA: 'us',
+
+  JPN: 'apac', AUS: 'apac', NZL: 'apac', KOR: 'apac',
+  SGP: 'apac', THA: 'apac', MYS: 'apac', PHL: 'apac',
+
+  GBR: 'eu', IRL: 'eu', ESP: 'eu', FRA: 'eu',
+  DEU: 'eu', GRC: 'eu', AUT: 'eu',
+};
+
+export const DEFAULT_HOSTS = {
+  us: 'be-api-s2s.intentiq.com',
+  apac: 'be-api-s2s-apac.intentiq.com',
+  eu: 'be-api-s2s-gdpr.intentiq.com',
+};
+
+// Fetch target, or a reason we must not fetch. Reasons stay distinct: an
+// unserved country and a device IntentIQ has no data for look the same in bid
+// volume and mean opposite things. Cache reads never call this.
+export function resolveRegion(country, regions) {
+  const name = COUNTRY_REGION[country];
+  if (!name) return { region: null, reason: 'country_unsupported' };
+
+  const region = regions?.[name];
+  const host = region?.host || DEFAULT_HOSTS[name];
+  if (!host) return { region: name, reason: 'region_unconfigured' };
+
+  // Supported mode, not a misconfiguration: read a cache others populate.
+  if (!region?.dpi) return { region: name, reason: 'no_dpi' };
+
+  return { region: name, host, dpi: String(region.dpi), reason: null };
+}

--- a/features/intent-iq/reporting.js
+++ b/features/intent-iq/reporting.js
@@ -1,0 +1,64 @@
+import { defineCounter } from '../../core/metrics.js';
+import { reportImpression } from './client.js';
+
+const BIDDING_PLATFORM_OPENRTB = '4';
+
+const reportTotal = defineCounter(
+  'smash_intent_iq_report_total',
+  'IntentIQ impression reports by result',
+  ['result'],
+);
+
+export function buildRdata(context) {
+  const iiq = context?.ext?.iiq;
+  if (!iiq?.dpi) return null;
+
+  // Number(null) is 0, so a missing price would be reported as a zero-cost
+  // impression and corrupt their attribution. Reject it before coercing.
+  if (context.price == null || context.price === '') return null;
+  const cpm = Number(context.price);
+  if (!Number.isFinite(cpm)) return null;
+
+  const currency = iiq.currency ?? 'USD';
+  const rdata = {
+    bidderCode: iiq.bidder ?? String(context.dsp ?? 'unknown'),
+    partnerId: iiq.dpi,
+    cpm,
+    currency,
+    originalCpm: cpm,
+    originalCurrency: currency,
+    biddingPlatformId: BIDDING_PLATFORM_OPENRTB,
+    placementId: iiq.placementId ?? '',
+    vrref: iiq.vrref ?? '',
+    partnerAuctionId: context.req ?? '',
+  };
+
+  if (iiq.abTestUuid) rdata.abTestUuid = iiq.abTestUuid;
+  if (iiq.ip) rdata.ip = iiq.ip;
+  if (iiq.ua) rdata.ua = iiq.ua;
+
+  return rdata;
+}
+
+// No dpi means this deployment never called IntentIQ, the one case their spec
+// exempts from reporting.
+export function createConsumer(cfg, send = reportImpression) {
+  return async context => {
+    if (!cfg.reporting?.enabled) return;
+
+    const rdata = buildRdata(context);
+    if (!rdata) { reportTotal.inc({ result: 'skipped' }); return; }
+
+    try {
+      const res = await send({
+        host: cfg.reporting.host,
+        dpi: rdata.partnerId,
+        rdata,
+        timeoutMs: cfg.reportTimeoutMs ?? 2000,
+      });
+      reportTotal.inc({ result: res.ok ? 'ok' : 'error' });
+    } catch {
+      reportTotal.inc({ result: 'error' });
+    }
+  };
+}

--- a/features/intent-iq/throttle.js
+++ b/features/intent-iq/throttle.js
@@ -1,0 +1,146 @@
+const FLOOR = 5;
+const CEIL = 5000;
+const ADD = 5;
+const DECREASE = 0.8;
+const EASE = 0.9;
+const SYNC_MS = 1000;
+const TTL_MS = 3600_000;
+
+const KEY = dpi => `iiq:thr:${dpi}`;
+
+// Recompute inside Redis: atomic, so no leader election. First worker in after
+// the interval elapses does it, the rest read.
+const SYNC_LUA = `
+local now_t = redis.call('TIME')
+local now = tonumber(now_t[1]) * 1000 + math.floor(tonumber(now_t[2]) / 1000)
+local out = {}
+for i, key in ipairs(KEYS) do
+  local o = (i - 1) * 5
+  redis.call('HINCRBY', key, 'd', tonumber(ARGV[o + 1]))
+  redis.call('HINCRBY', key, 'b', tonumber(ARGV[o + 2]))
+  redis.call('HINCRBY', key, 'o', tonumber(ARGV[o + 3]))
+  redis.call('HINCRBY', key, 'q', tonumber(ARGV[o + 4]))
+  redis.call('HINCRBY', key, 'e', tonumber(ARGV[o + 5]))
+
+  local h = redis.call('HMGET', key, 'r', 'ss', 'at', 'd', 'b', 'o', 'q', 'e', 'ld')
+  local r = tonumber(h[1]) or ${FLOOR}
+  local ss = tonumber(h[2]); if ss == nil then ss = 1 end
+  local at = tonumber(h[3]) or 0
+  local ld = tonumber(h[9]) or 0
+
+  if now - at >= ${SYNC_MS} then
+    local wd = tonumber(h[4]) or 0
+    local wb = tonumber(h[5]) or 0
+    local wo = tonumber(h[6]) or 0
+    local wq = tonumber(h[7]) or 0
+    local we = tonumber(h[8]) or 0
+
+    if wq > 0 then
+      r = math.max(${FLOOR}, r * ${DECREASE})
+      ss = 0
+    elseif we > 0 and we > wo then
+      r = math.max(${FLOOR}, r * ${EASE})
+      ss = 0
+    elseif wb > 0 then
+      if ss == 1 then r = math.min(${CEIL}, r * 2) else r = math.min(${CEIL}, r + ${ADD}) end
+    end
+
+    ld = wd
+    redis.call('HMSET', key, 'r', tostring(r), 'ss', ss, 'at', now, 'ld', ld,
+                             'd', 0, 'b', 0, 'o', 0, 'q', 0, 'e', 0)
+  end
+
+  redis.call('PEXPIRE', key, ${TTL_MS})
+  out[i] = tostring(r) .. ':' .. tostring(ld)
+end
+return out
+`;
+
+function newState(t) {
+  return { rate: FLOOR, tokens: FLOOR, refilled: t, demand: 0, blocked: 0, ok: 0, qps: 0, err: 0 };
+}
+
+export function createThrottle({ redis = () => null, now = () => Date.now() } = {}) {
+  const states = new Map();
+  let lastSync = 0;
+  let syncing = false;
+
+  const stateOf = dpi => {
+    let st = states.get(dpi);
+    if (!st) { st = newState(now()); states.set(dpi, st); }
+    return st;
+  };
+
+  // Demand is counted before the decision. Counting granted fetches instead
+  // would deadlock a worker that starts with no share.
+  function admit(dpi) {
+    const st = stateOf(dpi);
+    st.demand++;
+
+    const t = now();
+    st.tokens = Math.min(st.rate, st.tokens + (Math.max(0, t - st.refilled) / 1000) * st.rate);
+    st.refilled = t;
+
+    const allowed = st.tokens >= 1;
+    if (allowed) st.tokens -= 1;
+    else st.blocked++;
+
+    if (t - lastSync >= SYNC_MS && !syncing) {
+      lastSync = t;
+      void sync();
+    }
+    return allowed;
+  }
+
+  function record(dpi, outcome) {
+    const st = stateOf(dpi);
+    if (outcome === 'qps') st.qps++;
+    else if (outcome === 'error') st.err++;
+    else st.ok++;
+  }
+
+  async function sync() {
+    if (!states.size) return;
+    syncing = true;
+    try {
+      const client = await redis();
+
+      const dpis = [...states.keys()];
+      const args = [];
+      const mine = [];
+      for (const dpi of dpis) {
+        const st = states.get(dpi);
+        args.push(st.demand, st.blocked, st.ok, st.qps, st.err);
+        mine.push(st.demand);
+        st.demand = 0; st.blocked = 0; st.ok = 0; st.qps = 0; st.err = 0;
+      }
+
+      // Fail closed, unlike the rest of the feature: without coordination we
+      // cannot know the fleet total, and an outage must not become a flood.
+      if (!client) {
+        for (const dpi of dpis) stateOf(dpi).rate = FLOOR;
+        return;
+      }
+
+      let res;
+      try {
+        res = await client.eval(SYNC_LUA, { keys: dpis.map(KEY), arguments: args.map(String) });
+      } catch {
+        for (const dpi of dpis) stateOf(dpi).rate = FLOOR;
+        return;
+      }
+
+      dpis.forEach((dpi, i) => {
+        const [r, ld] = String(res?.[i] ?? '').split(':').map(Number);
+        if (!Number.isFinite(r)) return;
+        const total = Number.isFinite(ld) ? ld : 0;
+        const share = total > 0 && mine[i] > 0 ? r * (mine[i] / total) : FLOOR;
+        stateOf(dpi).rate = Math.max(FLOOR, Math.min(r, share));
+      });
+    } finally {
+      syncing = false;
+    }
+  }
+
+  return { admit, record, sync, _states: states, FLOOR, CEIL };
+}

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -70,3 +70,22 @@ test('tracked data stays nested, so it cannot be addressed as a flat metric labe
   assert.equal(out.abTestUuid, undefined);
   assert.equal(out['ext.iiq.abTestUuid'], undefined);
 });
+
+test('header() and endpoint() collect the outbound overrides', () => {
+  const ctx = makeCtx();
+  assert.equal(ctx.header('Authorization', 'Basic x'), ctx, 'chainable');
+  ctx.header('X-Other', '1');
+  assert.equal(ctx.endpoint('https://override.example/bid'), ctx, 'chainable');
+
+  assert.deepEqual(ctx._headers, { Authorization: 'Basic x', 'X-Other': '1' });
+  assert.equal(ctx._endpoint, 'https://override.example/bid');
+});
+
+test('timeLeft() subtracts elapsed time and the overhead, never going negative', () => {
+  const ctx = new BidContext({ tmax: 500 });
+  const left = ctx.timeLeft(10);
+  assert.ok(left > 0 && left <= 490, `expected just under 490, got ${left}`);
+
+  const tight = new BidContext({ tmax: 5 });
+  assert.equal(tight.timeLeft(100), 0, 'clamped at zero rather than reporting a negative budget');
+});

--- a/test/features/intent-iq-hook.test.js
+++ b/test/features/intent-iq-hook.test.js
@@ -1,0 +1,301 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { mergeConfig } from '../../core/utils.js';
+import { resolveConfig } from '../../core/config.js';
+import { _run } from '../../features/intent-iq/prebid-dsp.js';
+
+const DEFAULTS = JSON.parse(readFileSync(new URL('../../features/intent-iq/config.json', import.meta.url)));
+
+function cfgWith(over) {
+  return mergeConfig(mergeConfig(DEFAULTS, {
+    enabled: true,
+    redisUrl: 'redis://x',
+    regions: { us: { dpi: '111' }, eu: { host: 'gdpr.example', dpi: '333' } },
+  }), over);
+}
+
+function ctx({ country = 'USA', ifa = 'device-1', eids = [], params } = {}) {
+  const patches = [];
+  return {
+    dsp: { id: '333', endpointId: '4444', knownBidder: 'pubmatic', params: params ? { intentIq: params } : {} },
+    ssp: { id: '100', endpointId: '200' },
+    device: { country, ifa, ip: '1.2.3.4', ua: 'UA', os: 'iOS', osv: '17.5', type: 4 },
+    user: { id: null, eids },
+    publisher: { bundle: 'com.app', domain: null, name: null },
+    content: { page: null },
+    privacy: { gdpr: null, consent: null },
+    impression: { inventoryCode: 'slot-1' },
+    experimentByNs: {},
+    configOverrides: {},
+    meta: { requestId: 'r1', errors: [], warnings: [] },
+    _patches: patches,
+    set(path, value) { patches.push({ path, value }); return this; },
+    track(ns, data) { this._trackExt ??= {}; this._trackExt[ns] = { ...this._trackExt[ns], ...data }; return this; },
+    patch(path) { return patches.filter(p => p.path === path).at(-1)?.value; },
+  };
+}
+
+function redisWith(store = new Map(), { readThrows = false } = {}) {
+  return {
+    calls: { set: [] },
+    async get(k) { if (readThrows) throw new Error('down'); return store.get(k) ?? null; },
+    async set(k, v, opts) { this.calls.set.push({ k, v, opts }); store.set(k, v); },
+  };
+}
+
+const okGate = { admit: () => true, record: () => {} };
+const closedGate = { admit: () => false, record: () => {} };
+
+function fetchStub(result) {
+  const calls = [];
+  const fn = async args => { calls.push(args); return result; };
+  fn.calls = calls;
+  return fn;
+}
+
+const EIDS = [{ source: 'adsrvr.org', uids: [{ id: 'TTD-1' }] }];
+
+
+test('mergeConfig merges nested objects instead of replacing them', () => {
+  const out = mergeConfig({ a: { b: 1, c: 2 }, d: 3 }, { a: { c: 9 } });
+  assert.deepEqual(out, { a: { b: 1, c: 9 }, d: 3 });
+});
+
+test('mergeConfig replaces arrays rather than merging element-wise', () => {
+  assert.deepEqual(mergeConfig({ t: [{ a: 1 }, { b: 2 }] }, { t: [{ c: 3 }] }), { t: [{ c: 3 }] });
+});
+
+test('mergeConfig lets an explicit null win and ignores undefined', () => {
+  assert.deepEqual(mergeConfig({ a: { b: 1 } }, { a: null }), { a: null });
+  assert.deepEqual(mergeConfig({ a: 1 }, undefined), { a: 1 });
+});
+
+test('mergeConfig does not mutate its inputs', () => {
+  const base = { a: { b: 1 } };
+  mergeConfig(base, { a: { b: 2 } });
+  assert.deepEqual(base, { a: { b: 1 } });
+});
+
+test('a partial per-request region override keeps the other regions and its own host', () => {
+  const cfg = mergeConfig(cfgWith({}), { regions: { us: { dpi: '999' } } });
+  assert.equal(cfg.regions.us.dpi, '999');
+  assert.equal(cfg.regions.eu.dpi, '333', 'sibling region survived');
+  assert.equal(cfg.regions.eu.host, 'gdpr.example', 'sibling host survived');
+  assert.equal(cfg.regions.apac.dpi, '', 'region only present in defaults survived');
+});
+
+test('a partial reporting override keeps the host', () => {
+  const cfg = mergeConfig(cfgWith({}), { reporting: { enabled: false } });
+  assert.equal(cfg.reporting.enabled, false);
+  assert.equal(cfg.reporting.host, 'reports-s2s.intentiq.com');
+});
+
+test('resolveConfig applies an A/B variant override without flattening siblings', () => {
+  const c = { ...ctx(), configOverrides: { intentIq: { regions: { us: { dpi: 'AB' } } } } };
+  const cfg = resolveConfig(c, cfgWith({}), 'intentIq');
+  assert.equal(cfg.regions.us.dpi, 'AB');
+  assert.equal(cfg.regions.eu.host, 'gdpr.example');
+});
+
+
+test('a target miss passes the request through untouched', async () => {
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({ targets: [{ _side: 'ssp', knownBidder: 'nope' }] }), redisWith(), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+  assert.equal(c._patches.length, 0);
+});
+
+test('a request with no usable identity passes through', async () => {
+  const c = ctx({ ifa: null });
+  c.device.ip = null;
+  c.device.ua = null;
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({}), redisWith(), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('no Redis means the feature is off, not uncached — it never calls IntentIQ', async () => {
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({}), null, { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0, 'an outage must not turn every request into a fetch');
+  assert.equal(c._patches.length, 0);
+});
+
+test('a Redis read error passes through without fetching', async () => {
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({}), redisWith(new Map(), { readThrows: true }), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('a cache hit enriches without calling IntentIQ', async () => {
+  const store = new Map([['iiq:ifa:DEVICE-1', JSON.stringify({ eids: EIDS, abTestUuid: 'AB-1', dpi: '111' })]]);
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: [] });
+
+  await _run(c, cfgWith({}), redisWith(store), { fetch, gate: okGate });
+
+  assert.equal(fetch.calls.length, 0);
+  assert.deepEqual(c.patch('user.ext.eids'), EIDS);
+  assert.deepEqual(c.patch('user.eids'), EIDS);
+  assert.equal(c._trackExt.iiq.abTestUuid, 'AB-1');
+  assert.equal(c._trackExt.iiq.dpi, '111');
+  assert.equal(c._trackExt.iiq.bidder, 'pubmatic');
+  assert.equal(c._trackExt.iiq.placementId, 'slot-1');
+});
+
+test('a cached entry from another account does not lend its abTestUuid', async () => {
+  const store = new Map([['iiq:ifa:DEVICE-1', JSON.stringify({ eids: EIDS, abTestUuid: 'AB-OTHER', dpi: '999' })]]);
+  const c = ctx();
+  await _run(c, cfgWith({}), redisWith(store), { fetch: fetchStub({}), gate: okGate });
+  assert.equal(c._trackExt.iiq.abTestUuid, null);
+});
+
+test('a cached empty entry attaches nothing and still does not fetch', async () => {
+  const store = new Map([['iiq:ifa:DEVICE-1', JSON.stringify({ eids: [], abTestUuid: 'AB-1', dpi: '111' })]]);
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+
+  await _run(c, cfgWith({}), redisWith(store), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+  assert.equal(c.patch('user.ext.eids'), undefined);
+});
+
+test('an unserved country is never sent to IntentIQ', async () => {
+  const c = ctx({ country: 'UKR' });
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({}), redisWith(), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('without a dpi the feature reads the cache but never calls out', async () => {
+  const shared = new Map([['iiq:ifa:DEVICE-1', JSON.stringify({ eids: EIDS, abTestUuid: 'AB-1', dpi: '111' })]]);
+  const cfg = cfgWith({ regions: { us: { dpi: '' } } });
+
+  const hit = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(hit, cfg, redisWith(shared), { fetch, gate: okGate });
+  assert.deepEqual(hit.patch('user.ext.eids'), EIDS, 'still enriched from the shared cache');
+  assert.equal(hit._trackExt, undefined, 'nothing to report without an account');
+
+  const miss = ctx({ ifa: 'device-2' });
+  await _run(miss, cfg, redisWith(new Map()), { fetch, gate: okGate });
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('a throttled request passes through without fetching', async () => {
+  const c = ctx();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS });
+  await _run(c, cfgWith({}), redisWith(), { fetch, gate: closedGate });
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('a fetch attaches eids, caches them, and records the account that fetched', async () => {
+  const c = ctx();
+  const redis = redisWith();
+  const fetch = fetchStub({ outcome: 'ok', eids: EIDS, abTestUuid: 'AB-2', cttl: 600_000 });
+
+  await _run(c, cfgWith({}), redis, { fetch, gate: okGate });
+
+  assert.equal(fetch.calls[0].host, 'be-api-s2s.intentiq.com');
+  assert.equal(fetch.calls[0].dpi, '111');
+  assert.equal(fetch.calls[0].identity.pcid, 'DEVICE-1');
+  assert.deepEqual(c.patch('user.ext.eids'), EIDS);
+
+  const [write] = redis.calls.set;
+  assert.equal(write.k, 'iiq:ifa:DEVICE-1');
+  assert.deepEqual(JSON.parse(write.v), { eids: EIDS, abTestUuid: 'AB-2', dpi: '111' });
+  assert.equal(write.opts.PX, 600_000, 'their cttl is honoured');
+  assert.equal(c._trackExt.iiq.abTestUuid, 'AB-2');
+});
+
+test('an empty answer is cached so the same device is not asked again', async () => {
+  const c = ctx();
+  const redis = redisWith();
+  await _run(c, cfgWith({}), redis, { fetch: fetchStub({ outcome: 'ok', eids: [], cttl: 600_000 }), gate: okGate });
+
+  assert.equal(redis.calls.set.length, 1);
+  assert.deepEqual(JSON.parse(redis.calls.set[0].v).eids, []);
+  assert.equal(c.patch('user.ext.eids'), undefined);
+});
+
+test('a timeout or error caches nothing and leaves the request alone', async () => {
+  for (const outcome of ['timeout', 'error', 'qps', 'badjson']) {
+    const c = ctx();
+    const redis = redisWith();
+    await _run(c, cfgWith({}), redis, { fetch: fetchStub({ outcome }), gate: okGate });
+    assert.equal(redis.calls.set.length, 0, outcome);
+    assert.equal(c._patches.length, 0, outcome);
+  }
+});
+
+test('the cohort tier gets a shorter ttl than their cttl asks for', async () => {
+  const c = ctx({ ifa: null });
+  const redis = redisWith();
+  await _run(c, cfgWith({}), redis, { fetch: fetchStub({ outcome: 'ok', eids: EIDS, cttl: 86_400_000 }), gate: okGate });
+  assert.equal(redis.calls.set[0].opts.PX, DEFAULTS.coarseTtlMs);
+});
+
+test('incoming eids are kept and ours are only added for new sources', async () => {
+  const incoming = [
+    { source: 'adsrvr.org', uids: [{ id: 'SSP-OWN' }] },
+    { source: 'intentiq.com', uids: [{ id: 'UID-1' }] },
+  ];
+  const fresh = [
+    { source: 'adsrvr.org', uids: [{ id: 'IIQ-VERSION' }] },
+    { source: 'pubmatic.com', uids: [{ id: 'PM-1' }] },
+  ];
+  const c = ctx({ eids: incoming });
+  await _run(c, cfgWith({}), redisWith(), { fetch: fetchStub({ outcome: 'ok', eids: fresh }), gate: okGate });
+
+  const merged = c.patch('user.ext.eids');
+  assert.equal(merged.length, 3);
+  assert.equal(merged[0].uids[0].id, 'SSP-OWN', 'the SSP value is never overwritten');
+  assert.ok(merged.some(e => e.source === 'intentiq.com'));
+  assert.ok(merged.some(e => e.source === 'pubmatic.com'));
+});
+
+test('the incoming IIQ universal id is forwarded on the fetch', async () => {
+  const eids = [{ source: 'intentiq.com', uids: [{ id: 'UID-7' }] }];
+  const fetch = fetchStub({ outcome: 'ok', eids: [] });
+  await _run(ctx({ eids }), cfgWith({}), redisWith(), { fetch, gate: okGate });
+  assert.equal(fetch.calls[0].identity.iiquid, 'UID-7');
+});
+
+test('awaitFetch false returns before the answer and still stores it', async () => {
+  const c = ctx();
+  const redis = redisWith();
+  let release;
+  const fetch = async () => new Promise(r => { release = () => r({ outcome: 'ok', eids: EIDS, cttl: 1000 }); });
+
+  await _run(c, cfgWith({ awaitFetch: false }), redis, { fetch, gate: okGate });
+  assert.equal(c._patches.length, 0, 'the auction is not delayed');
+
+  release();
+  await new Promise(r => setTimeout(r, 0));
+  assert.equal(redis.calls.set.length, 1, 'the answer still lands in the cache');
+});
+
+test('a per-request region override wins over config on the wire', async () => {
+  const fetch = fetchStub({ outcome: 'ok', eids: [] });
+  const c = ctx({ params: { regions: { us: { dpi: 'REQ-DPI' } } } });
+  const cfg = mergeConfig(cfgWith({}), c.dsp.params.intentIq);
+  await _run(c, cfg, redisWith(), { fetch, gate: okGate });
+  assert.equal(fetch.calls[0].dpi, 'REQ-DPI');
+  assert.equal(fetch.calls[0].host, 'be-api-s2s.intentiq.com', 'the default host still resolves');
+});
+
+test('gdpr traffic goes to the gdpr account and carries the consent string', async () => {
+  const c = ctx({ country: 'GBR' });
+  c.privacy = { gdpr: 1, consent: 'CONSENT-STR' };
+  const fetch = fetchStub({ outcome: 'ok', eids: [] });
+  await _run(c, cfgWith({}), redisWith(), { fetch, gate: okGate });
+
+  assert.equal(fetch.calls[0].host, 'gdpr.example');
+  assert.equal(fetch.calls[0].dpi, '333');
+  assert.equal(fetch.calls[0].gdpr, 1);
+  assert.equal(fetch.calls[0].consent, 'CONSENT-STR');
+});

--- a/test/features/intent-iq-hook.test.js
+++ b/test/features/intent-iq-hook.test.js
@@ -202,7 +202,7 @@ test('a fetch attaches eids, caches them, and records the account that fetched',
 
   assert.equal(fetch.calls[0].host, 'be-api-s2s.intentiq.com');
   assert.equal(fetch.calls[0].dpi, '111');
-  assert.equal(fetch.calls[0].identity.pcid, 'DEVICE-1');
+  assert.equal(fetch.calls[0].identity.pcid, 'device-1', 'pcid sent as received');
   assert.deepEqual(c.patch('user.ext.eids'), EIDS);
 
   const [write] = redis.calls.set;

--- a/test/features/intent-iq-redis.test.js
+++ b/test/features/intent-iq-redis.test.js
@@ -1,0 +1,64 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRedis, _reset } from '../../features/intent-iq/redis.js';
+
+// Refused immediately, so nothing here waits on a network.
+const DEAD = 'redis://127.0.0.1:1';
+const OTHER = 'redis://127.0.0.1:2';
+
+afterEach(_reset);
+
+test('no url means no client', () => {
+  assert.equal(getRedis(''), null);
+  assert.equal(getRedis(undefined), null);
+});
+
+test('one connection per url, not one per process', async () => {
+  const a = getRedis(DEAD);
+  assert.equal(getRedis(DEAD), a, 'the same url shares the pending promise');
+
+  const b = getRedis(OTHER);
+  assert.notEqual(b, a, 'a different url gets its own connection');
+
+  await Promise.all([a, b]);
+});
+
+test('a connection that fails is forgotten, so the next call retries', async () => {
+  const first = getRedis(DEAD);
+  assert.equal(await first, null, 'fails open rather than throwing');
+
+  const second = getRedis(DEAD);
+  assert.notEqual(second, first, 'a dead server is not memoised for the process lifetime');
+  assert.equal(await second, null);
+});
+
+test('a malformed url fails open', async () => {
+  // createClient throws synchronously here, but connect() is async, so it
+  // reaches the caller as a rejection.
+  assert.equal(await getRedis('not-a-url'), null);
+  assert.equal(await getRedis('http://wrong-protocol'), null);
+});
+
+function fakeClient() {
+  const handlers = {};
+  return { on: (event, fn) => { handlers[event] = fn; }, emit: event => handlers[event]?.() };
+}
+
+test('a connection that drops is forgotten', async () => {
+  const client = fakeClient();
+  const connected = getRedis(DEAD, async () => client);
+
+  assert.equal(await connected, client);
+  assert.equal(getRedis(DEAD, async () => client), connected, 'memoised while alive');
+
+  // reconnectStrategy is false, so this client is gone for good.
+  client.emit('end');
+  assert.notEqual(getRedis(DEAD, async () => fakeClient()), connected,
+    'the dead client is not handed to the next caller');
+});
+
+test('a connect that throws synchronously fails open', () => {
+  assert.equal(getRedis(DEAD, () => { throw new Error('boom'); }), null);
+  assert.equal(getRedis(DEAD, async () => fakeClient()) === null, false,
+    'and nothing is left memoised to block the retry');
+});

--- a/test/features/intent-iq.test.js
+++ b/test/features/intent-iq.test.js
@@ -1,0 +1,437 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveRegion, COUNTRY_REGION, DEFAULT_HOSTS } from '../../features/intent-iq/regions.js';
+import { cacheKeyFor, cohortOf, surfaceOf, identityFor, hasRealIfa, IDTYPE } from '../../features/intent-iq/identity.js';
+import { createThrottle } from '../../features/intent-iq/throttle.js';
+import { ttlFor, abTestUuidFor, entryFor } from '../../features/intent-iq/cache.js';
+import { buildRdata, createConsumer } from '../../features/intent-iq/reporting.js';
+import { s2sPath, reportPath, interpretEids } from '../../features/intent-iq/client.js';
+
+const TTL_CFG = { ttlMs: 43_200_000, coarseTtlMs: 3_600_000, maxTtlMs: 86_400_000 };
+
+// now stays below SYNC_MS so admit() never fires a sync on its own.
+function throttleWith(rows, { fail = false } = {}) {
+  const calls = [];
+  const th = createThrottle({
+    now: () => 500,
+    redis: async () => (rows === null ? null : {
+      eval: async (_lua, opts) => {
+        calls.push(opts.arguments.map(Number));
+        if (fail) throw new Error('redis down');
+        return rows;
+      },
+    }),
+  });
+  return { th, calls };
+}
+
+const REGIONS = {
+  us: { dpi: '111' },
+  apac: { dpi: '' },
+  eu: { host: 'custom-gdpr.example', dpi: '333' },
+};
+
+function ctx({ device = {}, user = {}, publisher = {}, content = {}, ssp = { id: '100' } } = {}) {
+  return { device, user, publisher, content, ssp };
+}
+
+test('resolveRegion maps a country to its region, host and dpi', () => {
+  assert.deepEqual(resolveRegion('USA', REGIONS), {
+    region: 'us', host: DEFAULT_HOSTS.us, dpi: '111', reason: null,
+  });
+});
+
+test('resolveRegion honours a configured host over the default', () => {
+  assert.equal(resolveRegion('GBR', REGIONS).host, 'custom-gdpr.example');
+});
+
+test('resolveRegion reports an unserved country instead of guessing', () => {
+  assert.deepEqual(resolveRegion('UKR', REGIONS), { region: null, reason: 'country_unsupported' });
+  assert.equal(resolveRegion('POL', REGIONS).reason, 'country_unsupported', 'GDPR does not imply coverage');
+  assert.equal(resolveRegion(null, REGIONS).reason, 'country_unsupported');
+});
+
+test('resolveRegion reports no_dpi as a mode, not an error', () => {
+  const r = resolveRegion('JPN', REGIONS);
+  assert.equal(r.region, 'apac');
+  assert.equal(r.reason, 'no_dpi');
+  assert.equal(r.dpi, undefined);
+});
+
+test('every country in the table maps to a region that has a default host', () => {
+  for (const [country, region] of Object.entries(COUNTRY_REGION)) {
+    assert.ok(DEFAULT_HOSTS[region], `${country} -> ${region} has no default host`);
+  }
+  assert.equal(Object.keys(COUNTRY_REGION).length, 19);
+});
+
+test('hasRealIfa rejects a zero-filled opt-out IFA', () => {
+  assert.equal(hasRealIfa('00000000-0000-0000-0000-000000000000'), false);
+  assert.equal(hasRealIfa(''), false);
+  assert.equal(hasRealIfa(null), false);
+  assert.equal(hasRealIfa('e621e1f8-c36c-495a-93fc-0c247a3e6e5f'), true);
+});
+
+test('cacheKeyFor prefers the IFA tier and normalises case', () => {
+  const k = cacheKeyFor(ctx({ device: { ifa: 'abc-def', ip: '1.2.3.4', ua: 'x' } }));
+  assert.deepEqual(k, { tier: 'ifa', key: 'iiq:ifa:ABC-DEF' });
+});
+
+test('cacheKeyFor falls back to the cohort tier without an IFA', () => {
+  const k = cacheKeyFor(ctx({
+    device: { ifa: '00000000-0000-0000-0000-000000000000', ip: '203.0.113.42', os: 'iOS', osv: '17.5.1', type: 4, browsers: ['Safari'] },
+    content: { page: 'https://example.com' },
+  }));
+  assert.equal(k.tier, 'cohort');
+  assert.equal(k.key, 'iiq:ua:ios_17.5_mobile_webkit_site_203.0.113.42');
+});
+
+test('cacheKeyFor uses the IIQ UID only when there is no ip for a cohort', () => {
+  const eids = [{ source: 'intentiq.com', uids: [{ id: 'IIQ-UID-1' }] }];
+  const k = cacheKeyFor(ctx({ device: {}, user: { eids } }));
+  assert.deepEqual(k, { tier: 'iiquid', key: 'iiq:uid:IIQ-UID-1' });
+});
+
+test('cacheKeyFor is null when the request carries no identity at all', () => {
+  assert.equal(cacheKeyFor(ctx()), null);
+});
+
+test('cacheKeyFor never includes the dpi, so deployments share entries', () => {
+  const a = cacheKeyFor(ctx({ device: { ifa: 'same-device' } }));
+  const b = cacheKeyFor(ctx({ device: { ifa: 'same-device' }, ssp: { id: '999' } }));
+  assert.deepEqual(a, b);
+});
+
+test('engine ignores the "like Gecko" literal every webkit and blink UA carries', () => {
+  const safari = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15';
+  const chrome = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+  const firefox = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0';
+  const at = key => key.split('_')[3];
+
+  assert.equal(at(cohortOf(ctx({ device: { ip: '1.1.1.1', ua: safari } }))), 'webkit');
+  assert.equal(at(cohortOf(ctx({ device: { ip: '1.1.1.1', ua: chrome } }))), 'blink');
+  assert.equal(at(cohortOf(ctx({ device: { ip: '1.1.1.1', ua: firefox } }))), 'gecko');
+});
+
+test('engine skips the GREASE brand client hints inject', () => {
+  const browsers = ['Not/A)Brand', 'Chromium', 'Google Chrome'];
+  const key = cohortOf(ctx({ device: { ip: '1.1.1.1', os: 'Android', osv: '15', type: 4, browsers } }));
+  assert.equal(key.split('_')[3], 'blink');
+});
+
+test('cohort drops the patch version so a point release does not fragment the cache', () => {
+  const base = { ip: '1.1.1.1', os: 'Android', type: 4, browsers: ['Chrome'] };
+  const a = cohortOf(ctx({ device: { ...base, osv: '15.0.1' } }));
+  const b = cohortOf(ctx({ device: { ...base, osv: '15.0.7' } }));
+  assert.equal(a, b);
+  assert.notEqual(a, cohortOf(ctx({ device: { ...base, osv: '16.0.1' } })));
+});
+
+test('cohort falls back to the user agent only for what the protocol left empty', () => {
+  const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+  const key = cohortOf(ctx({ device: { ip: '9.9.9.9', ua }, publisher: { bundle: 'com.app' } }));
+  assert.equal(key, 'ios_18.3_mobile_webkit_app_9.9.9.9');
+});
+
+test('cohort is null without an ip', () => {
+  assert.equal(cohortOf(ctx({ device: { os: 'iOS', osv: '17.0' } })), null);
+});
+
+test('surfaceOf reads app vs site from the protocol, not the user agent', () => {
+  assert.equal(surfaceOf(ctx({ publisher: { bundle: 'com.app' } })), 'app');
+  assert.equal(surfaceOf(ctx({ content: { page: 'https://x.com' } })), 'site');
+  assert.equal(surfaceOf(ctx()), 'surface?');
+});
+
+test('identityFor sends idtype 4 with an uppercased IFA', () => {
+  const identity = identityFor(ctx({ device: { ifa: 'aaaa-bbbb', ip: '1.2.3.4', ua: 'UA' } }));
+  assert.equal(identity.idtype, IDTYPE.IFA);
+  assert.equal(identity.pcid, 'AAAA-BBBB');
+  assert.equal(identity.ip, '1.2.3.4');
+  assert.equal(identity.uas, 'UA');
+});
+
+test('identityFor sends idtype 8 for CTV and 0 for a site user id', () => {
+  const ctv = identityFor(ctx({ device: { ifa: 'roku-1', type: 3 } }));
+  assert.equal(ctv.idtype, IDTYPE.CTV);
+
+  const web = identityFor(ctx({ device: { ip: '1.1.1.1' }, user: { id: 'cookie-1' } }));
+  assert.equal(web.idtype, IDTYPE.COOKIE);
+  assert.equal(web.pcid, 'cookie-1');
+});
+
+test('identityFor forwards the IIQ universal id from the incoming eids', () => {
+  const eids = [{ source: 'intentiq.com', uids: [{ id: 'UID-9' }] }];
+  const identity = identityFor(ctx({ user: { eids } }));
+  assert.equal(identity.iiquid, 'UID-9');
+});
+
+
+
+test('throttle counts demand even while blocking, so a worker with no share still reports it', async () => {
+  const { th, calls } = throttleWith(['100:50']);
+  for (let i = 0; i < 12; i++) th.admit('D1');
+  await th.sync();
+
+  const [demand, blocked] = calls.at(-1);
+  assert.equal(demand, 12, 'every attempt counted, not just the granted ones');
+  assert.equal(blocked, 7, 'FLOOR granted, the rest recorded as blocked');
+});
+
+test('throttle takes a share proportional to its own demand', async () => {
+  const { th } = throttleWith(['100:50']);
+  for (let i = 0; i < 12; i++) th.admit('D1');
+  await th.sync();
+  // r=100, fleet demand=50, mine=12 -> 24
+  assert.equal(th._states.get('D1').rate, 24);
+});
+
+test('throttle never takes more than the discovered rate', async () => {
+  const { th } = throttleWith(['40:1']);
+  for (let i = 0; i < 12; i++) th.admit('D1');
+  await th.sync();
+  assert.equal(th._states.get('D1').rate, 40);
+});
+
+test('throttle holds the floor when the fleet reported no demand', async () => {
+  const { th } = throttleWith(['900:0']);
+  th.admit('D1');
+  await th.sync();
+  assert.equal(th._states.get('D1').rate, th.FLOOR);
+});
+
+test('throttle fails closed to the floor when Redis is unreachable', async () => {
+  const { th } = throttleWith(['500:1']);
+  th.admit('D1');
+  await th.sync();
+  assert.equal(th._states.get('D1').rate, 500);
+
+  const down = createThrottle({ now: () => 500, redis: async () => null });
+  down.admit('D1');
+  await down.sync();
+  assert.equal(down._states.get('D1').rate, down.FLOOR, 'an outage must not become a flood');
+});
+
+test('throttle fails closed when the sync script throws', async () => {
+  const { th } = throttleWith(['500:1'], { fail: true });
+  th.admit('D1');
+  await th.sync();
+  assert.equal(th._states.get('D1').rate, th.FLOOR);
+});
+
+test('throttle keeps separate budgets per dpi in one round trip', async () => {
+  const { th, calls } = throttleWith(['100:10', '200:10']);
+  th.admit('DPI-A');
+  th.admit('DPI-B');
+  th.admit('DPI-B');
+  await th.sync();
+
+  assert.equal(calls.length, 1, 'one Redis call regardless of dpi count');
+  assert.deepEqual(calls[0], [1, 0, 0, 0, 0, 2, 0, 0, 0, 0]);
+  assert.equal(th._states.get('DPI-A').rate, 10);
+  assert.equal(th._states.get('DPI-B').rate, 40);
+});
+
+test('throttle separates their QPS limit from transport errors', async () => {
+  const { th, calls } = throttleWith(['100:10']);
+  th.admit('D1');
+  th.record('D1', 'qps');
+  th.record('D1', 'error');
+  th.record('D1', 'ok');
+  await th.sync();
+
+  const [, , ok, qps, err] = calls.at(-1);
+  assert.deepEqual([ok, qps, err], [1, 1, 1]);
+});
+
+test('ttlFor prefers the cttl IntentIQ sent', () => {
+  assert.equal(ttlFor(600_000, 'ifa', TTL_CFG), 600_000);
+});
+
+test('ttlFor falls back to the configured default for a missing or bad cttl', () => {
+  assert.equal(ttlFor(undefined, 'ifa', TTL_CFG), TTL_CFG.ttlMs);
+  assert.equal(ttlFor(0, 'ifa', TTL_CFG), TTL_CFG.ttlMs);
+  assert.equal(ttlFor('nope', 'ifa', TTL_CFG), TTL_CFG.ttlMs);
+});
+
+test('ttlFor caps a cttl that would pin stale eids', () => {
+  assert.equal(ttlFor(999_999_999, 'ifa', TTL_CFG), TTL_CFG.maxTtlMs);
+});
+
+test('ttlFor keeps the cohort tier short — it is a bucket of devices, not one device', () => {
+  assert.equal(ttlFor(86_400_000, 'cohort', TTL_CFG), TTL_CFG.coarseTtlMs);
+  assert.equal(ttlFor(60_000, 'cohort', TTL_CFG), 60_000, 'a shorter cttl still wins');
+});
+
+test('abTestUuid is only reused for the account that fetched it', () => {
+  const entry = entryFor([], 'AB-1', '111');
+  assert.equal(abTestUuidFor(entry, '111'), 'AB-1');
+  assert.equal(abTestUuidFor(entry, '222'), null, 'another account must not report it');
+  assert.equal(abTestUuidFor(entryFor([], 'AB-1', null), '111'), null);
+});
+
+test('buildRdata skips a deployment with no dpi of its own', () => {
+  assert.equal(buildRdata({ price: 1.5, ext: { iiq: { abTestUuid: 'AB-1' } } }), null);
+  assert.equal(buildRdata({ price: 1.5 }), null);
+});
+
+test('buildRdata skips when there is no price to report', () => {
+  assert.equal(buildRdata({ ext: { iiq: { dpi: '111' } } }), null);
+});
+
+test('buildRdata fills the reporting payload from the token', () => {
+  const r = buildRdata({
+    price: 1.18, req: 'req-1', dsp: '333',
+    ext: { iiq: { dpi: '111', abTestUuid: 'AB-1', bidder: 'pubmatic', placementId: 'div1', vrref: 'cnnApp', ip: '1.2.3.4', ua: 'UA' } },
+  });
+  assert.equal(r.bidderCode, 'pubmatic');
+  assert.equal(r.partnerId, '111');
+  assert.equal(r.cpm, 1.18);
+  assert.equal(r.currency, 'USD');
+  assert.equal(r.biddingPlatformId, '4');
+  assert.equal(r.abTestUuid, 'AB-1');
+  assert.equal(r.partnerAuctionId, 'req-1');
+});
+
+test('buildRdata falls back to the dsp id when the bidder is unrecognised', () => {
+  const r = buildRdata({ price: 1, dsp: '333', ext: { iiq: { dpi: '111' } } });
+  assert.equal(r.bidderCode, '333');
+});
+
+test('buildRdata omits abTestUuid rather than sending an empty one', () => {
+  const r = buildRdata({ price: 1, dsp: '333', ext: { iiq: { dpi: '111' } } });
+  assert.equal('abTestUuid' in r, false);
+});
+
+test('s2sPath carries the static params, the dpi and the identity', () => {
+  const p = s2sPath('123', { ip: '1.2.3.4', uas: 'Mozilla/5.0 (X)', pcid: 'ABC', idtype: 4 });
+  const q = new URLSearchParams(p.split('?')[1]);
+
+  assert.equal(p.split('?')[0], '/profiles_engine/ProfilesEngineServlet');
+  assert.equal(q.get('at'), '39');
+  assert.equal(q.get('mi'), '10');
+  assert.equal(q.get('pt'), '17');
+  assert.equal(q.get('dpn'), '1');
+  assert.equal(q.get('srvrReq'), 'true');
+  assert.equal(q.get('dpi'), '123');
+  assert.equal(q.get('uas'), 'Mozilla/5.0 (X)', 'user agent survives encoding intact');
+  assert.equal(q.get('idtype'), '4');
+});
+
+test('s2sPath declares iiqidtype only alongside an iiquid', () => {
+  const withUid = new URLSearchParams(s2sPath('1', { iiquid: 'UID' }).split('?')[1]);
+  assert.equal(withUid.get('iiqidtype'), '2', 'the docs require the pair to travel together');
+
+  const without = new URLSearchParams(s2sPath('1', { ip: '1.1.1.1' }).split('?')[1]);
+  assert.equal(without.get('iiqidtype'), null);
+});
+
+test('reportPath url-encodes rdata as one JSON value', () => {
+  const rdata = { bidderCode: 'pubmatic', cpm: 1.18, currency: 'USD', abTestUuid: 'a-b-c' };
+  const q = new URLSearchParams(reportPath('123', rdata).split('?')[1]);
+
+  assert.equal(q.get('at'), '45');
+  assert.equal(q.get('rtype'), '1');
+  assert.equal(q.get('dpi'), '123');
+  assert.deepEqual(JSON.parse(q.get('rdata')), rdata, 'round-trips through the query string');
+});
+
+test('interpretEids reads a good response', () => {
+  const body = JSON.stringify({
+    data: { eids: [{ source: 'adsrvr.org', uids: [{ id: 'x' }] }] },
+    abTestUuid: 'uuid-1',
+    cttl: 86400000,
+  });
+  assert.deepEqual(interpretEids({ status: 'ok', code: 200, body }), {
+    outcome: 'ok',
+    eids: [{ source: 'adsrvr.org', uids: [{ id: 'x' }] }],
+    abTestUuid: 'uuid-1',
+    cttl: 86400000,
+  });
+});
+
+test('interpretEids treats 302 as no data, not a redirect', () => {
+  assert.equal(interpretEids({ status: 'ok', code: 302, body: '' }).outcome, 'nodata');
+});
+
+test('interpretEids spots the QPS refusal inside an otherwise fine response', () => {
+  const res = { status: 'ok', code: 200, body: '{"error":"QPS_LIMIT_REACHED"}' };
+  assert.equal(interpretEids(res).outcome, 'qps', 'must not be read as a parse failure');
+});
+
+test('interpretEids separates a timeout from an error', () => {
+  assert.equal(interpretEids({ status: 'timeout' }).outcome, 'timeout');
+  assert.equal(interpretEids({ status: 'error' }).outcome, 'error');
+  assert.equal(interpretEids({ status: 'ok', code: 503, body: '' }).outcome, 'error');
+});
+
+test('interpretEids reports unparseable json distinctly', () => {
+  assert.equal(interpretEids({ status: 'ok', code: 200, body: '{oops' }).outcome, 'badjson');
+});
+
+test('interpretEids honours isOptedOut over any eids present', () => {
+  const body = JSON.stringify({ isOptedOut: true, data: { eids: [{ source: 'x' }] }, cttl: 600000 });
+  const out = interpretEids({ status: 'ok', code: 200, body });
+  assert.deepEqual(out.eids, [], 'an opted-out user yields nothing regardless of payload');
+  assert.equal(out.cttl, 600000);
+});
+
+test('interpretEids caches an empty answer rather than treating it as failure', () => {
+  const body = JSON.stringify({ data: { eids: [] }, abTestUuid: 'u', cttl: 600000 });
+  const out = interpretEids({ status: 'ok', code: 200, body });
+  assert.equal(out.outcome, 'ok');
+  assert.deepEqual(out.eids, []);
+  assert.equal(out.cttl, 600000, 'their short ttl for a miss is preserved');
+});
+
+const IIQ_CTX = {
+  price: 1.18, dsp: '333', req: 'req-1',
+  ext: { iiq: { dpi: '123', abTestUuid: 'u-1', vrref: 'com.app', placementId: 'slot-1', ip: '1.2.3.4', ua: 'UA' } },
+};
+
+function consumerWith(cfg, result = { ok: true, code: 200 }) {
+  const sent = [];
+  const send = async args => { sent.push(args); if (result instanceof Error) throw result; return result; };
+  return { run: createConsumer(cfg, send), sent };
+}
+
+test('the impression consumer sends the report to the configured host', async () => {
+  const { run, sent } = consumerWith({ reporting: { enabled: true, host: 'reports.example' } });
+  await run(IIQ_CTX);
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].host, 'reports.example');
+  assert.equal(sent[0].dpi, '123');
+  assert.equal(sent[0].rdata.abTestUuid, 'u-1');
+  assert.equal(sent[0].rdata.cpm, 1.18);
+  assert.equal(sent[0].rdata.biddingPlatformId, '4');
+});
+
+test('the consumer sends nothing when reporting is off', async () => {
+  const { run, sent } = consumerWith({ reporting: { enabled: false, host: 'reports.example' } });
+  await run(IIQ_CTX);
+  assert.equal(sent.length, 0);
+});
+
+test('the consumer sends nothing without a dpi — the one case their spec exempts', async () => {
+  const { run, sent } = consumerWith({ reporting: { enabled: true, host: 'h' } });
+  await run({ price: 1, ext: { iiq: { abTestUuid: 'u' } } });
+  await run({ price: 1 });
+  assert.equal(sent.length, 0);
+});
+
+test('the consumer survives a transport failure without throwing', async () => {
+  const { run } = consumerWith({ reporting: { enabled: true, host: 'h' } }, new Error('socket died'));
+  await run(IIQ_CTX);
+});
+
+test('the consumer survives a rejected report without throwing', async () => {
+  const { run, sent } = consumerWith({ reporting: { enabled: true, host: 'h' } }, { ok: false, code: 503 });
+  await run(IIQ_CTX);
+  assert.equal(sent.length, 1);
+});
+
+test('buildRdata refuses a non-numeric price rather than reporting nonsense', () => {
+  assert.equal(buildRdata({ ...IIQ_CTX, price: null }), null);
+  assert.equal(buildRdata({ ...IIQ_CTX, price: 'free' }), null);
+});

--- a/test/features/intent-iq.test.js
+++ b/test/features/intent-iq.test.js
@@ -303,9 +303,12 @@ test('buildRdata omits abTestUuid rather than sending an empty one', () => {
   assert.equal('abTestUuid' in r, false);
 });
 
+// URLSearchParams is not in the eslint globals allowlist; URL is.
+const params = path => new URL(`https://h${path}`).searchParams;
+
 test('s2sPath carries the static params, the dpi and the identity', () => {
   const p = s2sPath('123', { ip: '1.2.3.4', uas: 'Mozilla/5.0 (X)', pcid: 'ABC', idtype: 4 });
-  const q = new URLSearchParams(p.split('?')[1]);
+  const q = params(p);
 
   assert.equal(p.split('?')[0], '/profiles_engine/ProfilesEngineServlet');
   assert.equal(q.get('at'), '39');
@@ -319,16 +322,16 @@ test('s2sPath carries the static params, the dpi and the identity', () => {
 });
 
 test('s2sPath declares iiqidtype only alongside an iiquid', () => {
-  const withUid = new URLSearchParams(s2sPath('1', { iiquid: 'UID' }).split('?')[1]);
+  const withUid = params(s2sPath('1', { iiquid: 'UID' }));
   assert.equal(withUid.get('iiqidtype'), '2', 'the docs require the pair to travel together');
 
-  const without = new URLSearchParams(s2sPath('1', { ip: '1.1.1.1' }).split('?')[1]);
+  const without = params(s2sPath('1', { ip: '1.1.1.1' }));
   assert.equal(without.get('iiqidtype'), null);
 });
 
 test('reportPath url-encodes rdata as one JSON value', () => {
   const rdata = { bidderCode: 'pubmatic', cpm: 1.18, currency: 'USD', abTestUuid: 'a-b-c' };
-  const q = new URLSearchParams(reportPath('123', rdata).split('?')[1]);
+  const q = params(reportPath('123', rdata));
 
   assert.equal(q.get('at'), '45');
   assert.equal(q.get('rtype'), '1');

--- a/test/features/intent-iq.test.js
+++ b/test/features/intent-iq.test.js
@@ -156,12 +156,21 @@ test('cohort no longer depends on publisher.bundle or content.page', () => {
   assert.equal(cohortOf(withFields), cohortOf(without), 'same device, same key either way');
 });
 
-test('identityFor sends idtype 4 with an uppercased IFA', () => {
+test('identityFor sends the IFA exactly as received', () => {
+  // Their footnote puts the uppercase rule on IDFV alone, and an AAID is
+  // conventionally lower case, so normalising it would send an id nobody else
+  // sends and fail to resolve.
   const identity = identityFor(ctx({ device: { ifa: 'aaaa-bbbb', ip: '1.2.3.4', ua: 'UA' } }));
   assert.equal(identity.idtype, IDTYPE.IFA);
-  assert.equal(identity.pcid, 'AAAA-BBBB');
+  assert.equal(identity.pcid, 'aaaa-bbbb');
   assert.equal(identity.ip, '1.2.3.4');
   assert.equal(identity.uas, 'UA');
+});
+
+test('the cache key still folds case, even though the outgoing pcid does not', () => {
+  const lower = cacheKeyFor(ctx({ device: { ifa: 'aaaa-bbbb' } }));
+  const upper = cacheKeyFor(ctx({ device: { ifa: 'AAAA-BBBB' } }));
+  assert.deepEqual(lower, upper, 'one device, one entry');
 });
 
 test('identityFor sends idtype 8 for CTV and 0 for a site user id', () => {
@@ -334,12 +343,15 @@ test('s2sPath carries the static params, the dpi and the identity', () => {
   assert.equal(q.get('idtype'), '4');
 });
 
-test('s2sPath declares iiqidtype only alongside an iiquid', () => {
-  const withUid = params(s2sPath('1', { iiquid: 'UID' }));
-  assert.equal(withUid.get('iiqidtype'), '2', 'the docs require the pair to travel together');
-
-  const without = params(s2sPath('1', { ip: '1.1.1.1' }));
-  assert.equal(without.get('iiqidtype'), null);
+test('s2sPath sends iiquid without iiqidtype', () => {
+  // iiqidtype describes iiqpcid, the browser-side first-party id, and the docs
+  // require iiqpcid, iiqidtype and iiqpciddate to travel together. We have no
+  // first-party id server-side, so sending one of the three alone was wrong.
+  const q = params(s2sPath('1', { iiquid: 'UID' }));
+  assert.equal(q.get('iiquid'), 'UID');
+  assert.equal(q.get('iiqidtype'), null);
+  assert.equal(q.get('iiqpcid'), null);
+  assert.equal(q.get('iiqpciddate'), null);
 });
 
 test('reportPath url-encodes rdata as one JSON value', () => {

--- a/test/features/intent-iq.test.js
+++ b/test/features/intent-iq.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { resolveRegion, COUNTRY_REGION, DEFAULT_HOSTS } from '../../features/intent-iq/regions.js';
-import { cacheKeyFor, cohortOf, surfaceOf, identityFor, hasRealIfa, IDTYPE } from '../../features/intent-iq/identity.js';
+import { cacheKeyFor, cohortOf, identityFor, hasRealIfa, IDTYPE } from '../../features/intent-iq/identity.js';
 import { createThrottle } from '../../features/intent-iq/throttle.js';
 import { ttlFor, abTestUuidFor, entryFor } from '../../features/intent-iq/cache.js';
 import { buildRdata, createConsumer } from '../../features/intent-iq/reporting.js';
@@ -31,8 +31,8 @@ const REGIONS = {
   eu: { host: 'custom-gdpr.example', dpi: '333' },
 };
 
-function ctx({ device = {}, user = {}, publisher = {}, content = {}, ssp = { id: '100' } } = {}) {
-  return { device, user, publisher, content, ssp };
+function ctx({ device = {}, user = {}, publisher = {}, content = {}, ssp = { id: '100' }, inventory = null } = {}) {
+  return { device, user, publisher, content, ssp, inventory };
 }
 
 test('resolveRegion maps a country to its region, host and dpi', () => {
@@ -80,7 +80,7 @@ test('cacheKeyFor prefers the IFA tier and normalises case', () => {
 test('cacheKeyFor falls back to the cohort tier without an IFA', () => {
   const k = cacheKeyFor(ctx({
     device: { ifa: '00000000-0000-0000-0000-000000000000', ip: '203.0.113.42', os: 'iOS', osv: '17.5.1', type: 4, browsers: ['Safari'] },
-    content: { page: 'https://example.com' },
+    inventory: 'site',
   }));
   assert.equal(k.tier, 'cohort');
   assert.equal(k.key, 'iiq:ua:ios_17.5_mobile_webkit_site_203.0.113.42');
@@ -129,7 +129,7 @@ test('cohort drops the patch version so a point release does not fragment the ca
 
 test('cohort falls back to the user agent only for what the protocol left empty', () => {
   const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
-  const key = cohortOf(ctx({ device: { ip: '9.9.9.9', ua }, publisher: { bundle: 'com.app' } }));
+  const key = cohortOf(ctx({ device: { ip: '9.9.9.9', ua }, inventory: 'app' }));
   assert.equal(key, 'ios_18.3_mobile_webkit_app_9.9.9.9');
 });
 
@@ -137,10 +137,23 @@ test('cohort is null without an ip', () => {
   assert.equal(cohortOf(ctx({ device: { os: 'iOS', osv: '17.0' } })), null);
 });
 
-test('surfaceOf reads app vs site from the protocol, not the user agent', () => {
-  assert.equal(surfaceOf(ctx({ publisher: { bundle: 'com.app' } })), 'app');
-  assert.equal(surfaceOf(ctx({ content: { page: 'https://x.com' } })), 'site');
-  assert.equal(surfaceOf(ctx()), 'surface?');
+test('cohort takes app vs site from ctx.inventory, not from optional fields', () => {
+  const base = { ip: '1.1.1.1', os: 'iOS', osv: '17.0', type: 4, browsers: ['Safari'] };
+  const at = key => key.split('_')[4];
+
+  // bundle and page are optional, so an app request that omits bundle must
+  // still read as app — the old guess returned neither.
+  assert.equal(at(cohortOf({ ...ctx({ device: base }), inventory: 'app' })), 'app');
+  assert.equal(at(cohortOf({ ...ctx({ device: base }), inventory: 'site' })), 'site');
+  assert.equal(at(cohortOf({ ...ctx({ device: base }), inventory: 'dooh' })), 'dooh');
+  assert.equal(at(cohortOf(ctx({ device: base }))), 'inv?', 'no inventory object at all');
+});
+
+test('cohort no longer depends on publisher.bundle or content.page', () => {
+  const base = { ip: '1.1.1.1', os: 'iOS', osv: '17.0', type: 4, browsers: ['Safari'] };
+  const withFields = { ...ctx({ device: base, publisher: { bundle: 'com.app' } }), inventory: 'app' };
+  const without = { ...ctx({ device: base }), inventory: 'app' };
+  assert.equal(cohortOf(withFields), cohortOf(without), 'same device, same key either way');
 });
 
 test('identityFor sends idtype 4 with an uppercased IFA', () => {


### PR DESCRIPTION
Open for collaboration rather than for merging. Draft on purpose — the feature works end to end but is not finished, and the remaining decisions need answers from IntentIQ, not from us.

It ships `enabled: false`, so it does nothing until a deployment configures a `dpi`.

## What it does

Resolves external ids for the user against the IntentIQ S2S Bid Enhancement API, merges them into `user.ext.eids` before the DSP call, and reports the rendered impression back so lift can be measured.

| File | |
|---|---|
| `regions.js` | country → (host, dpi) |
| `identity.js` | pcid/idtype and the cache key, per the caching guide |
| `cache.js` | Redis entries on the server-supplied `cttl` |
| `client.js` | HTTP/2 to the S2S and reporting endpoints |
| `throttle.js` | self-discovering rate limit, coordinated per dpi |
| `reporting.js` | impression report, wired through the tracking service |
| `prebid-dsp.js` | the hook — fail-open on every branch |

Three shapes that were deliberate rather than incidental:

**A region is a `(host, dpi)` pair, not just a host.** The GDPR endpoint is a separate IntentIQ account. Kept apart, the two would drift and eventually send one account's token to another account's endpoint. Only the documented countries are served, and `eu` is those seven rather than the EU or GDPR jurisdictions generally.

**The cache key carries no dpi.** That is what lets a deployment without an account read a cache that deployments with one populate. Keyed on device identity, with the UA+IP tier reduced to coarse components instead of the raw string, so a patch-version bump does not mint a new entry.

**Rate is discovered, not configured.** A local bucket admits requests with no Redis on the hot path; workers agree a fleet-wide limit per dpi through Redis at most once a second and share it in proportion to demand. Demand is counted before the throttle decision, otherwise a worker with no share could never register demand and so could never earn one.

## What is missing

The first four need IntentIQ:

- **`3rdpcid` / `3rddpi` are not implemented.** They are ordered pairs of repeated query params, and the numeric codes per SSP/DSP have to come from IntentIQ. This is the piece most likely to matter: a proxy already receives eids on the inbound request, so feeding known ids back lets the graph resolve a user when IP and UA cannot.
- **Is the eids payload partner-specific?** If a response differs by `dpi`, a dpi-free shared cache is serving one partner data resolved for another, and the caching design needs revisiting.
- **An agreed QPS.** The throttle discovers a ceiling by probing, which works, but knowing the intended number lets it start near it instead of climbing.
- **Does `pai` apply here, and is a separate GDPR account provisioned?**

And two on our side:

- Which side of `ext.smash` carries the per-request `awaitFetch` / `regions` override.
- The collision rule when merging our eids with ones already present on the request. Merging rather than replacing is settled; which id wins on a shared `source` is not.

## Working on this

Fork and open a pull request against this branch. No access to anything else is needed.

One request: this repository is public. Account ids, `dpi` values and agreed rate limits do not belong in code, issues or pull request descriptions. Configuration is gitignored, so nothing leaks from a normal change, but the fields around a change are easy to forget.

## State
- `npm test` — 354/354
- `npm run coverage` — 91.09 / 86.93 / 85.60, over the gate
- `npm run lint` — clean

Transport in `client.js` is intentionally uncovered, as in `core/client.js`. The logic that sits around it is covered: query construction, the `gdpr-consent` header, url-encoded `rdata`, and the overlapping response signals where `302` means no data rather than a redirect and a QPS refusal arrives in the body of an otherwise fine 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional IntentIQ identity enrichment for eligible bid requests.
  * Added regional routing, caching, throttling, impression reporting, GDPR-aware handling, and fail-open behavior.
  * Added support for identifying app, site, and digital out-of-home inventory.
  * Added configurable IntentIQ settings, disabled by default.

* **Improvements**
  * Improved Redis connection recovery and connection sharing.
  * Preserved existing identifiers while adding newly available identity data.

* **Documentation**
  * Added setup and behavior documentation for IntentIQ integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->