### PR TITLE
Raise engines to >=22, and quote the test globs so Windows expands them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,7 @@ npm run lint
 npm run coverage   # tests again, with thresholds
 ```
 
-Node 22 or newer. `package.json` still says `>=20`, but the test script hands
-glob patterns to `node --test` and those are only expanded from Node 21 on.
+Node 22 or newer — `package.json` `engines` now says so too.
 
 ## Where code goes
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test 'test/**/*.test.js' 'test/*.test.js'",
+    "test": "node --test \"test/**/*.test.js\" \"test/*.test.js\"",
     "lint": "eslint .",
-    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=90 --test-coverage-branches=84 --test-coverage-functions=85 'test/**/*.test.js' 'test/*.test.js'"
+    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude=\"test/**\" --test-coverage-lines=90 --test-coverage-branches=84 --test-coverage-functions=85 \"test/**/*.test.js\" \"test/*.test.js\""
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "prom-client": "^15.1.3",


### PR DESCRIPTION
Closes #7. Took the **first** option — `engines` is now `>=22`.

That is the choice the rest of the repository had already made: the README says "Node 22 or newer", CI pins 22, and CONTRIBUTING carries a note explaining the mismatch. `engines: >=20` was the single line disagreeing with all three, so raising it removes a contradiction rather than adding a constraint. The CONTRIBUTING note goes with it.

## The quoting had to change too

This is the part the issue does not cover, and it turns out to be the worse half.

npm runs scripts through `cmd.exe` on Windows, and cmd does **not** strip single quotes. So `node --test` receives `'test/**/*.test.js'` — quotes included — as a literal path, matches nothing, and:

```
$ npm test
> node --test 'test/**/*.test.js' 'test/*.test.js'

ℹ tests 0
ℹ pass 0
ℹ fail 0
exit=0
```

A green suite that ran no tests. That is strictly worse than the Node 20 failure in the issue, which at least says `Could not find`. On Windows the script has been a no-op the whole time, and nothing says so.

Raising `engines` alone would not have touched it — on Node 22 + Windows you still get 0 tests and exit 0.

**Double quotes fix both platforms.** cmd strips them; POSIX shells strip them too and still stop the shell from expanding the pattern, so Node does the expanding either way. Same machine, same command, after the change:

```
ℹ tests 272
ℹ pass 272
ℹ fail 0
exit=0
```

The `coverage` script had the same two bugs — the pattern arguments *and* `--test-coverage-exclude='test/**'` — so it is quoted the same way rather than left as the next thing to trip over.

## Why not the second option

I tried it. `node --test test/` does not do what it looks like: Node treats **every** file under a directory named `test` as a test file regardless of name, so it picks up `test/demo.js` and `test/adapters/helpers.js`. `demo.js` fails, taking the suite red for a reason that has nothing to do with the tests. Keeping `>=20` that way would mean moving or renaming those two files, which is a bigger change than the engine bump and touches things the issue does not ask about.

## Verified

Windows, Node 24.17.0:

| | |
|---|---|
| `npm test` | 272 tests, 272 pass, exit 0 — was **0 tests, exit 0** |
| `npm run coverage` | 91.51% lines / 86.93% branches / 87.11% functions, exit 0 |
| `npm run lint` | clean |

**What I could not check:** only Node 24 is installed here, so I have not run this on 20 or 22. The claim that 22 is the true floor rests on your analysis plus the README and CI, not on a run of my own. If you want the `>=20` route after all, say so and I will do the file moves instead.

*(A note for anyone else reproducing on Windows: `core.autocrlf=false` is worth setting first, or every file shows as modified.)*
