### PR TITLE
Clarify Apache licensing and copyright ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,16 @@ client fork inherits core, so a change there lands on all of them.
 
 ## Licensing of contributions
 
-The project is [Apache 2.0](LICENSE). By opening a pull request you certify that
-you wrote the change or otherwise have the right to submit it under that
-licence, and that you are willing for it to be distributed under it.
+The project is licensed under the [Apache License, Version 2.0](LICENSE).
+
+Unless explicitly stated otherwise, any contribution intentionally submitted
+for inclusion in this project is provided to xDD Group, UAB under the Apache
+License, Version 2.0, without additional terms or conditions, as described in
+Section 5 of the license.
+
+By submitting a contribution, you represent that you have the right to submit
+it under those terms. Do not submit material owned by an employer, client, or
+other third party unless you have the necessary permission.
 
 ## Security
 

--- a/LICENSE
+++ b/LICENSE
@@ -176,24 +176,13 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 xDD Group, UAB
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -176,13 +175,24 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 xDD Group, UAB
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 xDD Group, UAB.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       https://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -61,4 +61,14 @@ Questions and bug reports: [open an issue](https://github.com/xe-works/xdd-smash
 
 ## License
 
-[Apache 2.0](LICENSE). The framework is open; feature modules and support are offered separately.
+Copyright 2026 xDD Group, UAB.
+
+This project is licensed under the [Apache License, Version 2.0](LICENSE).
+
+Unless otherwise explicitly stated, the license applies to all source code,
+feature modules, services, tests, documentation, and other material contained
+in this repository.
+
+Additional modules, integrations, managed hosting, implementation services,
+and support not contained in this repository may be offered separately under
+commercial terms.


### PR DESCRIPTION
## Summary

- identify xDD Group, UAB as the copyright owner
- replace the generic Apache application template with a concrete copyright notice
- clarify which repository materials are licensed under Apache-2.0
- clarify the licensing and authority requirements for contributions
- distinguish public repository contents from separately offered commercial services and modules

## Rationale

The repository already uses Apache License 2.0. This change makes the copyright owner, repository-wide scope, and inbound contribution terms explicit while preserving Sections 1–9 of the standard Apache terms.

The concrete license notice follows the structure used by Prebid.js.

## Verification

- `git diff --check`
- license notice validation
- `npm test`
- `npm run lint`
- `npm run coverage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified contribution licensing terms and contributor submission requirements.
  - Updated the project license notice to identify xDD Group, UAB and reference the Apache License 2.0.
  - Expanded README licensing information to cover repository contents and clarify that external services or offerings may be provided under separate commercial terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->